### PR TITLE
Fixed bug preventing options fields from showing.

### DIFF
--- a/app/assets/scripts/descriptor.js
+++ b/app/assets/scripts/descriptor.js
@@ -27,7 +27,7 @@ $(document).ready(function () {
 
     // This is for the new descriptor page
     $("#desc_type").change(function() {
-        if ($(this).val() === "Option") {
+        if ($(this).val() === "option") {
             $("#values-div").show();
         } else {
             $("#values-div").hide();


### PR DESCRIPTION
In Firefox 60.0.2 (64-bit), selecting the descriptor type "Option" did not cause option entry fields to be displayed.  I used the console to show the hidden (by default) div and was then able to create an options descriptor.

This commit is so that Heroku will pick up the change I believe will allow us to create descriptors of type "Option."